### PR TITLE
removed old kiyv layout code in assessment manager to properly render…

### DIFF
--- a/kv/AssessmentManager.kv
+++ b/kv/AssessmentManager.kv
@@ -2,11 +2,7 @@
 
     FloatLayout:
         id: assessment_grid
-        cols: 2
-        padding: 10, 10
-        spacing: 10, 10
-        size_hint_y: None
-        row_default_height: 500
+       
         Label:
             color: 0, 2, 3, 9
             id: name


### PR DESCRIPTION
Removed old Kivy layout code in the assessment manager Kivy file. This was preventing the drag and drop widget from being rendered properly. I just deleted the unneeded code and the widget is display as should. 