### PR TITLE
fixed size for dnd

### DIFF
--- a/components/DragAndDrop.py
+++ b/components/DragAndDrop.py
@@ -46,7 +46,7 @@ class DragAndDrop(BoxLayout):
     def _replace_image(self, id):
         old_widget = self._get_id(id)
         self.ids.to_box.remove_widget(old_widget)
-        self.ids.to_box.add_widget(Image(source='assets/drag-and-drop/shape' + id + '.png',opacity = 0), index=(3 - int(id)))
+        self.ids.to_box.add_widget(Image(source=self.ordered_image_ids[int(id) - 1], size=(250, 350)),index=(3 - int(id)))
 
     def call_back(self, id, *largs):
         self._replace_image(id)

--- a/kv/draganddrop.kv
+++ b/kv/draganddrop.kv
@@ -15,60 +15,52 @@
     BoxLayout:
         orientation: 'vertical'
         id: from_box
-        pos_hint: {'center_x': .3, 'center_y': .5}
-        size_hint_x: dnd_from_style['layout_size_x']
-        size_hint_y: dnd_from_style['layout_size_y']
-
         spacing: dnd_from_style['spacing']
 
         DraggableButton:
             text: '1'
-            pos: 150, 900
             color: 0, 0, 0, 0
             droppable_zone_objects: [box_1]
             drop_func: root.correct
             failed_drop_func: root.wrong
-            size_hint: dnd_from_style['size_hint']
+            size_hint: None, None
+            size: 250, 350
 
             Image:
                 source: root.ordered_image_ids[0]
                 y: self.parent.y
                 x: self.parent.x
                 size: self.parent.size
-                allow_stretch: False
 
         DraggableButton:
             text: '2'
-            pos: 150, 600
             color: app_style['assessment_background']
             droppable_zone_objects: [box_2]
             drop_func: root.correct
             failed_drop_func: root.wrong
-            size_hint: dnd_from_style['size_hint']
-
+            size_hint: None, None
+            size: 250, 350
 
             Image:
                 source: root.ordered_image_ids[1]
                 y: self.parent.y
                 x: self.parent.x
                 size: self.parent.size
-                allow_stretch: False
 
         DraggableButton:
             text: '3'
-            pos: 150, 300
             color: app_style['assessment_background']
             droppable_zone_objects: [box_3]
             drop_func: root.correct
             failed_drop_func: root.wrong
-            size_hint: dnd_from_style['size_hint']
+            size_hint: None, None
+            size: 250, 350
 
             Image:
                 source: root.ordered_image_ids[2]
                 y: self.parent.y
                 x: self.parent.x
                 size: self.parent.size
-                allow_stretch: False
 
     BoxLayout:
 


### PR DESCRIPTION
currently the replace image on correct is commented out. if you uncomment it, it works but appears slightly buggy. I don't have time to fully fix it now but the images no longer resize.  they disappear when you get them correct. 